### PR TITLE
implemented 'days' and 'only_live_offers' params for product_search

### DIFF
--- a/keepa/_version.py
+++ b/keepa/_version.py
@@ -1,6 +1,6 @@
 """Version number for keepa
 """
 # major, minor, patch, -extra
-version_info = 1, 2, 1
+version_info = 1, 3, 0
 
 __version__ = '.'.join(map(str, version_info))


### PR DESCRIPTION
Added implementation and passing tests for both 'days' and 'only_live_offers' params for a product_search.

**Note for the 'days' param:**
If the 'days' param is specified, Keepa will return truncated historical data for these fields:
- csv
- buyBoxSellerIdHistory
- salesRanks
- offers 
- offers.offerCSV fields

However, there is a bug from Keepa.
We must remove the all the datapoints corresponding to the *single oldest* day of data in each field of historical data. 
That day is **always** out of range.
This is what made the implementation of the 'days' param tricky to me. 
First, there was a global bug we reported to Keepa to have it fixed. 
Then there is this minor bug which took me a while to figure out.

In any case, until Keepa adresses this bug, this PR should be passing.
Cheers,