### PR TITLE
Implementation of 'days' and 'only_live_offers' params for product_search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+# Simple makefile to simplify repetitive build env management tasks under posix
+
+CODESPELL_DIRS ?= ./
+CODESPELL_SKIP ?= "*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./docs/_build/*,./docs/images/*,./dist/*,*~,.hypothesis*,./docs/examples/*,*.mypy_cache/*,*cover,./tests/htmlcov/*,*.css,*.svg"
+CODESPELL_IGNORE ?= "ignore_words.txt"
+
+all: doctest
+
+doctest: codespell pydocstyle
+
+codespell:
+	@echo "Running codespell"
+	@codespell $(CODESPELL_DIRS) -S $(CODESPELL_SKIP) -I $(CODESPELL_IGNORE)
+
+pydocstyle:
+	@echo "Running pydocstyle"
+	@pydocstyle pyvista
+
+doctest-modules:
+	@echo "Runnnig module doctesting"
+	pytest -v --doctest-modules pyvista
+
+coverage:
+	@echo "Running coverage"
+	@pytest -v --cov pyvista
+
+coverage-xml:
+	@echo "Reporting XML coverage"
+	@pytest -v --cov pyvista --cov-report xml
+
+coverage-html:
+	@echo "Reporting HTML coverage"
+	@pytest -v --cov pyvista --cov-report html
+
+mypy:
+	@echo "Running mypy static type checking"
+	mypy pyvista/core/ --no-incremental

--- a/docs/source/product_query.rst
+++ b/docs/source/product_query.rst
@@ -55,7 +55,10 @@ The ``products`` variable is a list of product data with one entry per successfu
     print('ASIN is ' + products[0]['asin'])
     print('Title is ' + products[0]['title'])
 
-When the parameter ``history`` is True (enabled by default, the each product contains a The raw data is contained within each product result. Raw data is stored as a dictonary with each key paired with its associated time history.
+When the parameter ``history`` is True (enabled by default, the each
+product contains a The raw data is contained within each product
+result. Raw data is stored as a dictionary with each key paired with
+its associated time history.
 
 .. code:: python
 

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -1,0 +1,3 @@
+lod
+byteorder
+flem

--- a/keepa/_version.py
+++ b/keepa/_version.py
@@ -1,6 +1,6 @@
 """Version number for keepa
 """
 # major, minor, patch, -extra
-version_info = 1, 2, 1
+version_info = 1, 3, 0
 
 __version__ = '.'.join(map(str, version_info))

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -358,10 +358,9 @@ class AsyncKeepa():
         self.tokens_left = 0
 
         # Store user's available tokens
-        log.info('Connecting to keepa using key ending in %s' % accesskey[-6:])
+        log.info('Connecting to keepa using key ending in %s', accesskey[-6:])
         await self.update_status()
-        log.info('%d tokens remain' % self.tokens_left)
-
+        log.info('%d tokens remain', self.tokens_left)
         return self
 
     @property
@@ -497,28 +496,31 @@ class AsyncKeepa():
             parameter is required.
 
         wait : bool, optional
-            Wait available token before doing effective query, Defaults to ``True``.
+            Wait available token before doing effective query,
+            Defaults to ``True``.
 
         only_live_offers : bool, optional
             If set to True, the product object will only include live
-            marketplace offers (when used in combination with the offers parameter).
-            If you do not need historical offers use this to have them removed from
-            the response. This can improve processing time and considerably
-            decrease the size of the response.
-            Default None
+            marketplace offers (when used in combination with the
+            offers parameter).  If you do not need historical offers
+            use this to have them removed from the response. This can
+            improve processing time and considerably decrease the size
+            of the response.  Default None
 
         days : int, optional
-            Any positive integer value. If specified and has positive value X
-            the product object will limit all historical data to the recent X days.
-            This includes the csv, buyBoxSellerIdHistory, salesRanks, offers
-            and offers.offerCSV fields. If you do not need old historical data
-            use this to have it removed from the response. This can improve
-            processing time and considerably decrease the size of the response.
-            The parameter does not use calendar days - so 1 day equals the last 24 hours.
-            The oldest data point of each field may have a date value which is out of
-            the specified range. This means the value of the field has not changed since that date
-            and is still active.
-            Default None
+            Any positive integer value. If specified and has positive
+            value X the product object will limit all historical data
+            to the recent X days.  This includes the csv,
+            buyBoxSellerIdHistory, salesRanks, offers and
+            offers.offerCSV fields. If you do not need old historical
+            data use this to have it removed from the response. This
+            can improve processing time and considerably decrease the
+            size of the response.  The parameter does not use calendar
+            days - so 1 day equals the last 24 hours.  The oldest data
+            point of each field may have a date value which is out of
+            the specified range. This means the value of the field has
+            not changed since that date and is still active.  Default
+            ``None``
 
         Returns
         -------
@@ -663,7 +665,8 @@ class AsyncKeepa():
 
         # check offer input
         if offers:
-            assert isinstance(offers, int), 'Parameter "offers" must be an interger'
+            if not isinstance(offers, int):
+                raise TypeError('Parameter "offers" must be an interger')
 
             if offers > 100 or offers < 20:
                 raise ValueError('Parameter "offers" must be between 20 and 100')
@@ -673,9 +676,9 @@ class AsyncKeepa():
             60000 - self.status['refillIn']) / 60000.0
         if tcomplete < 0.0:
             tcomplete = 0.5
-        log.debug('Estimated time to complete %d request(s) is %.2f minutes' %
-                  (nitems, tcomplete))
-        log.debug('\twith a refill rate of %d token(s) per minute' %
+        log.debug('Estimated time to complete %d request(s) is %.2f minutes',
+                  nitems, tcomplete)
+        log.debug('\twith a refill rate of %d token(s) per minute',
                   self.status['refillRate'])
 
         # product list
@@ -881,7 +884,8 @@ class AsyncKeepa():
             Default US
 
         wait : bool, optional
-            Wait available token before doing effective query, Defaults to ``True``.
+            Wait available token before doing effective query.
+            Defaults to ``True``.
 
         Returns
         -------
@@ -911,7 +915,8 @@ class AsyncKeepa():
             Input search term.
 
         wait : bool, optional
-            Wait available token before doing effective query, Defaults to ``True``.
+            Wait available token before doing effective query.
+            Defaults to ``True``.
 
         Returns
         -------
@@ -942,7 +947,8 @@ class AsyncKeepa():
         else:
             return response['categories']
 
-    async def category_lookup(self, category_id, domain='US', include_parents=0, wait=True):
+    async def category_lookup(self, category_id, domain='US',
+                              include_parents=0, wait=True):
         """
         Return root categories given a categoryId.
 
@@ -961,7 +967,8 @@ class AsyncKeepa():
             Include parents.
 
         wait : bool, optional
-            Wait available token before doing effective query, Defaults to ``True``.
+            Wait available token before doing effective query.
+            Defaults to ``True``.
 
         Returns
         -------
@@ -1035,21 +1042,23 @@ class AsyncKeepa():
 
             Using this parameter you can achieve the following:
 
-            - Retrieve data from Amazon: a storefront ASIN list containing
-              up to 2,400 ASINs, in addition to all ASINs already collected
-              through our database.
-            - Force a refresh: Always retrieve live data with the value 0.
-            - Retrieve the total number of listings of this seller: the
-              totalStorefrontAsinsCSV field of the seller object will be
-              updated.
+            - Retrieve data from Amazon: a storefront ASIN list
+              containing up to 2,400 ASINs, in addition to all ASINs
+              already collected through our database.
+            - Force a refresh: Always retrieve live data with the
+              value 0.
+            - Retrieve the total number of listings of this seller:
+              the totalStorefrontAsinsCSV field of the seller object
+              will be updated.
 
         wait : bool, optional
-            Wait available token before doing effective query, Defaults to ``True``.
+            Wait available token before doing effective query.
+            Defaults to ``True``.
 
         Returns
         -------
         seller_info : dict
-            Dictionary containing one entry per input seller_id.
+            Dictionary containing one entry per input ``seller_id``.
 
         Examples
         --------
@@ -2241,11 +2250,11 @@ def convert_offer_history(csv, to_datetime=True):
     Parameters
     ----------
     csv : list
-       Offer list csv obtained from ['offerCSV']
+       Offer list csv obtained from ``['offerCSV']``
 
     to_datetime : bool, optional
-        Modifies numpy minutes to datetime.datetime values.
-        Default True.
+        Modifies ``numpy`` minutes to ``datetime.datetime`` values.
+        Default ``True``.
 
     Returns
     -------

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -367,7 +367,7 @@ class AsyncKeepa():
     @property
     def time_to_refill(self):
         """ Returns the time to refill in seconds """
-        # Get current timestamp in miliseconds from unix epoch
+        # Get current timestamp in milliseconds from UNIX epoch
         now = int(time.time() * 1000)
         timeatrefile = self.status['timestamp'] + self.status['refillIn']
 
@@ -763,7 +763,7 @@ class AsyncKeepa():
             ASINs.
 
         refillIn : float
-            Time in miliseconds to the next refill of tokens.
+            Time in milliseconds to the next refill of tokens.
 
         refilRate : float
             Number of tokens refilled per minute
@@ -2131,7 +2131,7 @@ class AsyncKeepa():
 
         You can find products that recently changed and match your
         search criteria.  A single request will return a maximum of
-        150 deals.  Try ou the deals page to frist get accustomed to
+        150 deals.  Try out the deals page to first get accustomed to
         the options:
         https://keepa.com/#!deals
 
@@ -2203,7 +2203,7 @@ class AsyncKeepa():
 
     async def _request(self, request_type, payload, wait=True):
         """Queries keepa api server.  Parses raw response from keepa
-        into a json format.  Handles errors and waits for avaialbe
+        into a json format.  Handles errors and waits for available
         tokens if allowed.
         """
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -191,6 +191,7 @@ def test_productquery_offers(api):
     assert len(times)
     assert len(prices)
 
+
 def test_productquery_only_live_offers(api):
     """Tests that no historical offer data was returned from response if only_live_offers param was specified."""
     max_offers = 20
@@ -204,40 +205,33 @@ def test_productquery_only_live_offers(api):
     last_seen_values = {offer['lastSeen'] for offer in product_offers}
     assert len(last_seen_values) == 1
 
+
 def test_productquery_days(api, max_days: int = 5):
     """Tests that 'days' param limits historical data to X days.
-    This includes the csv, buyBoxSellerIdHistory, salesRanks, offers and offers.offerCSV fields."""
+    This includes the csv, buyBoxSellerIdHistory, salesRanks, offers and offers.offerCSV fields.
+    Each field may contain one day which seems out of specified range. This means the value of the field has been
+    unchanged since that date, and was still active at least until the max_days cutoff."""
 
     request = api.query(PRODUCT_ASIN, days=max_days, history=True, offers=20)
     product = request[0]
-    historical_data = {
-        # CSV and OffersCSV are handled seperately at the end of this test.
-        'sales_ranks': list(chain.from_iterable(product['salesRanks'].values()))[0::2],
-        'offers': {offer['lastSeen'] for offer in product['offers']},
-        'buy_box_seller_id_history': product['buyBoxSellerIdHistory'][0::2],
-    }
+    convert = lambda minutes: list(set(keepa_minutes_to_time(keepa_minute).date() for keepa_minute in minutes))
 
+    # Converting each field's list of keepa minutes into flat list of unique days.
+    sales_ranks = convert(chain.from_iterable(product['salesRanks'].values()))[0::2]
+    offers = convert(offer['lastSeen'] for offer in product['offers'])
+    buy_box_seller_id_history = convert(product['buyBoxSellerIdHistory'][0::2])
+    offers_csv = list(convert(offer['offerCSV'][0::3]) for offer in product['offers'])
+    df_dates = list(list(df.axes[0]) for df_name, df in product['data'].items() if 'df_' in df_name and any(df))
+    df_dates = list(list(datetime.date(year=ts.year, month=ts.month, day=ts.day) for ts in stamps) for stamps in df_dates)
+
+    # Check for out of range days.
     today = datetime.date.today()
     is_out_of_range = lambda d: (today - d).days > max_days
-    for name, minutes in historical_data.items():
-        # Convert Keepa minutes to list of unique date (not datetime) objs.
-        days_of_data = list(set(keepa_minutes_to_time(minute).date() for minute in minutes))
-        for day in days_of_data:
-            assert not is_out_of_range(day), f'{name}, {day}'
-
-    # Data / CSV
-    dates = chain.from_iterable(list(df.axes[0]) for df_name, df in product['data'].items() if 'df_' in df_name and any(df))
-    dates = sorted(list(set(datetime.date(year=stamp.year, month=stamp.month, day=stamp.day) for stamp in dates)))
-    for day in dates:
-        assert not is_out_of_range(day), f'{day}'
-
-    # Offers CSV
-    offers_csv_minutes = [offer['offerCSV'][0::3] for offer in product['offers']]
-    offers_csv_days = list(set(keepa_minutes_to_time(minutes).date() for minutes in chain.from_iterable(offers_csv_minutes)))
-    offers_csv_days.sort()
-    for day in offers_csv_days:
-        assert not is_out_of_range(day), f'{day}'
-
+    for field_days in [sales_ranks, offers, buy_box_seller_id_history, *df_dates, *offers_csv]:
+        field_days.sort()
+        field_days = field_days[1:] if is_out_of_range(field_days[0]) else field_days  # let oldest day be out of range
+        for day in field_days:
+            assert not is_out_of_range(day), day
 
 def test_productquery_offers_invalid(api):
     with pytest.raises(ValueError):


### PR DESCRIPTION
Implementation of 'days' and 'only_live_offers' params for product_search.

Adjusted the tests according to useful information from the Keepa team :
https://discuss.keepa.com/t/api-product-search-days-param-only-works-along-with-offers-param/12567/7
