### PR TITLE
Add product keys

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           pip install twine
           python setup.py sdist
-          twine upload --skip-existing dist/keepa*.gz        
+          twine upload --skip-existing dist/keepa*.tar.gz
         env: # Or as an environment variable
           TWINE_USERNAME: "__token__"
           TWINE_PASSWORD: ${{ secrets.TWINE_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Documentation can be found on readthedocs at `keepa Documentation <https://keepa
 
 Requirements
 ------------
-Module is compatible with Python >= 3.5 and requires:
+Module is compatible with Python >= 3.6 and requires:
 
  - ``numpy``
  - ``aiohttp``
@@ -220,6 +220,7 @@ If you plan to do a lot of simulatneous query, you might want to speedup query u
 .. code:: python
 
     products = await api.query('059035342X', wait=False)
+
 
 Credits
 -------

--- a/keepa/_version.py
+++ b/keepa/_version.py
@@ -1,6 +1,13 @@
 """Version number for keepa
+
+On the ``main`` branch, use 'dev0' to denote a development version.
+For example:
+
+version_info = 0, 27, 'dev0'
+
+
 """
-# major, minor, patch, -extra
-version_info = 1, 3, 0
+# major, minor, patch
+version_info = 1, 3, 'dev0'
 
 __version__ = '.'.join(map(str, version_info))

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -337,6 +337,13 @@ class Keepa():
     accesskey : str
         64 character access key string.
 
+    timeout : float, optional
+        Default timeout when issuing any request.  This is not a time
+        limit on the entire response download; rather, an exception is
+        raised if the server has not issued a response for timeout
+        seconds.  Setting this to 0 disables the timeout, but will
+        cause any request to hang indefiantly should keepa.com be down
+
     Examples
     --------
     Create the api object
@@ -363,10 +370,11 @@ class Keepa():
     >>> print('\t as of: {:s}'.format(str(usedtimes[-1])))
     """
 
-    def __init__(self, accesskey):
+    def __init__(self, accesskey, timeout=10):
         self.accesskey = accesskey
         self.status = None
         self.tokens_left = 0
+        self._timeout = timeout
 
         # Store user's available tokens
         log.info('Connecting to keepa using key ending in %s', accesskey[-6:])
@@ -2242,8 +2250,8 @@ class Keepa():
             self.wait_for_tokens()
 
         while True:
-            raw = requests.get('https://api.keepa.com/%s/?' %
-                               request_type, payload)
+            raw = requests.get(f'https://api.keepa.com/{request_type}/?', payload,
+                               timeout=self._timeout)
             status_code = str(raw.status_code)
             if status_code != '200':
                 if status_code in SCODES:
@@ -2286,6 +2294,13 @@ class AsyncKeepa():
     accesskey : str
         64 character access key string.
 
+    timeout : float, optional
+        Default timeout when issuing any request.  This is not a time
+        limit on the entire response download; rather, an exception is
+        raised if the server has not issued a response for timeout
+        seconds.  Setting this to 0 disables the timeout, but will
+        cause any request to hang indefiantly should keepa.com be down
+
     Examples
     --------
     Create the api object
@@ -2313,11 +2328,12 @@ class AsyncKeepa():
     """
 
     @classmethod
-    async def create(cls, accesskey):
+    async def create(cls, accesskey, timeout=10):
         self = AsyncKeepa()
         self.accesskey = accesskey
         self.status = None
         self.tokens_left = 0
+        self._timeout = timeout
 
         # Store user's available tokens
         log.info('Connecting to keepa using key ending in %s', accesskey[-6:])
@@ -2620,7 +2636,8 @@ class AsyncKeepa():
         while True:
             async with aiohttp.ClientSession() as session:
                 async with session.get(
-                    'https://api.keepa.com/%s/?' % request_type, params=payload
+                    f'https://api.keepa.com/{request_type}/?', params=payload,
+                    timeout=self._timeout
                 ) as raw:
                     status_code = str(raw.status)
                     if status_code != '200':

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -542,7 +542,8 @@ class Keepa():
             ``None``
 
         raw : bool, optional
-            When ``True``, return the raw request response.
+            When ``True``, return the raw request response.  This is
+            only available in the non-async class.
 
         Returns
         -------
@@ -2381,6 +2382,9 @@ class AsyncKeepa():
                     rating=False, out_of_stock_as_nan=True, stock=False,
                     product_code_is_asin=True, progress_bar=True, buybox=False,
                     wait=True, days=None, only_live_offers=None, raw=False):
+        if raw:
+            raise ValueError('Raw response is only available in the non-async class')
+
         # Format items into numpy array
         try:
             items = format_items(items)
@@ -2627,7 +2631,7 @@ class AsyncKeepa():
         response = await self._request('query', payload, wait=wait)
         return response['asinList']
 
-    async def _request(self, request_type, payload, wait=True, raw_response=False):
+    async def _request(self, request_type, payload, wait=True):
         """Queries keepa api server.  Parses raw response from keepa
         into a json format.  Handles errors and waits for available
         tokens if allowed.

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -2364,7 +2364,7 @@ class AsyncKeepa():
                     offers=None, update=None, to_datetime=True,
                     rating=False, out_of_stock_as_nan=True, stock=False,
                     product_code_is_asin=True, progress_bar=True, buybox=False,
-                    wait=True, days=None, only_live_offers=None):
+                    wait=True, days=None, only_live_offers=None, raw=False):
         # Format items into numpy array
         try:
             items = format_items(items)
@@ -2611,7 +2611,7 @@ class AsyncKeepa():
         response = await self._request('query', payload, wait=wait)
         return response['asinList']
 
-    async def _request(self, request_type, payload, wait=True):
+    async def _request(self, request_type, payload, wait=True, raw_response=False):
         """Queries keepa api server.  Parses raw response from keepa
         into a json format.  Handles errors and waits for available
         tokens if allowed.

--- a/keepa/plotting.py
+++ b/keepa/plotting.py
@@ -40,21 +40,21 @@ def plot_product(product, keys=['AMAZON', 'USED', 'COUNT_USED', 'SALES'],
 
     # Create three figures, one for price data, offers, and sales rank
     pricefig, priceax = plt.subplots(figsize=(10, 5))
-    pricefig.canvas.set_window_title('Product Price Plot')
+    pricefig.canvas.manager.set_window_title('Product Price Plot')
     plt.title(product['title'])
     plt.xlabel('Date')
     plt.ylabel('Price')
     pricelegend = []
 
     offerfig, offerax = plt.subplots(figsize=(10, 5))
-    offerfig.canvas.set_window_title('Product Offer Plot')
+    offerfig.canvas.manager.set_window_title('Product Offer Plot')
     plt.title(product['title'])
     plt.xlabel('Date')
     plt.ylabel('Listings')
     offerlegend = []
 
     salesfig, salesax = plt.subplots(figsize=(10, 5))
-    salesfig.canvas.set_window_title('Product Sales Rank Plot')
+    salesfig.canvas.manager.set_window_title('Product Sales Rank Plot')
     plt.title(product['title'])
     plt.xlabel('Date')
     plt.ylabel('Sales Rank')

--- a/keepa/query_keys.py
+++ b/keepa/query_keys.py
@@ -1028,4 +1028,13 @@ PRODUCT_REQUEST_KEYS = {
     'type': list,
     'mpn': list,
     'outOfStockPercentage90_lte': int,
-    'outOfStockPercentage90_gte': int}
+    'outOfStockPercentage90_gte': int,
+    "itemHeight_lte": int,
+    "itemHeight_gte": int,
+    "itemLength_lte": int,
+    "itemLength_gte": int,
+    "itemWidth_lte": int,
+    "itemWidth_gte": int,
+    "itemWeight_lte": int,
+    "itemWeight_gte": int,
+}

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,8 +1,6 @@
 pytest
 pytest-cov
-pytest-asyncio
-# only to support python 3.5
-async_generator
+pytest-asyncio==0.14.0
 codecov
 matplotlib
 pandas

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,7 +1,6 @@
 pytest
 pytest-cov
-pytest-asyncio==0.14.0
-async_generator
+pytest-asyncio
 codecov
 matplotlib
 pandas

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
 pytest
 pytest-cov
 pytest-asyncio==0.14.0
+async_generator
 codecov
 matplotlib
 pandas

--- a/tests/test_async_interface.py
+++ b/tests/test_async_interface.py
@@ -142,6 +142,13 @@ async def test_product_finder_query(api):
 #     keepa.interface.REQLIM = 2
 
 
+def test_productquery_raw(api):
+    request = api.query(PRODUCT_ASIN, history=False, raw=True)
+    raw = request[0]
+    assert isinstance(raw, requests.Response)
+    assert PRODUCT_ASIN in raw.text
+
+
 @pytest.mark.asyncio
 async def test_productquery_nohistory(api):
     pre_update_tokens = api.tokens_left

--- a/tests/test_async_interface.py
+++ b/tests/test_async_interface.py
@@ -28,8 +28,8 @@ if os.path.isfile(keyfile):
         WEAKTESTINGKEY = f.read()
 else:
     # from travis-ci or appveyor
-    TESTINGKEY = os.environ.get("KEEPAKEY")
-    WEAKTESTINGKEY = os.environ.get("WEAKKEEPAKEY")
+    TESTINGKEY = os.environ["KEEPAKEY"]
+    WEAKTESTINGKEY = os.environ["WEAKKEEPAKEY"]
 
 # harry potter book ISBN
 PRODUCT_ASIN = "0439064872"

--- a/tests/test_async_interface.py
+++ b/tests/test_async_interface.py
@@ -1,14 +1,12 @@
+import datetime
+import requests
 import os
 
 import numpy as np
 import pytest
 import pandas as pd
-
-# only to support python 3.5
-from async_generator import yield_, async_generator
-
 import keepa
-import datetime
+
 
 # reduce the request limit for testing
 keepa.interface.REQLIM = 2
@@ -87,12 +85,12 @@ PRODUCT_ASINS = [
 
 # open connection to keepa
 @pytest.fixture
-@async_generator
+# @async_generator
 async def api():
     keepa_api = await keepa.AsyncKeepa.create(TESTINGKEY)
     assert keepa_api.tokens_left
     assert keepa_api.time_to_refill >= 0
-    await yield_(keepa_api)
+    yield keepa_api
 
 
 @pytest.mark.asyncio
@@ -142,11 +140,10 @@ async def test_product_finder_query(api):
 #     keepa.interface.REQLIM = 2
 
 
-def test_productquery_raw(api):
-    request = api.query(PRODUCT_ASIN, history=False, raw=True)
-    raw = request[0]
-    assert isinstance(raw, requests.Response)
-    assert PRODUCT_ASIN in raw.text
+@pytest.mark.asyncio
+async def test_productquery_raw(api):
+    with pytest.raises(ValueError):
+        request = await api.query(PRODUCT_ASIN, history=False, raw=True)
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_interface.py
+++ b/tests/test_async_interface.py
@@ -109,20 +109,6 @@ async def test_deals(api):
 
 
 @pytest.mark.asyncio
-async def test_invalidkey():
-    with pytest.raises(Exception):
-        keepa.Api("thisisnotavalidkey")
-
-
-@pytest.mark.asyncio
-async def test_deadkey():
-    with pytest.raises(Exception):
-        # this key returns "payment required"
-        deadkey = "8ueigrvvnsp5too0atlb5f11veinerkud" "47p686ekr7vgr9qtj1t1tle15fffkkm"
-        keepa.Api(deadkey)
-
-
-@pytest.mark.asyncio
 async def test_product_finder_categories(api):
     product_parms = {"categories_include": ["1055398"]}
     products = await api.product_finder(product_parms)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,3 +1,4 @@
+import requests
 import warnings
 import datetime
 import os
@@ -28,18 +29,20 @@ if os.path.isfile(keyfile):
         WEAKTESTINGKEY = f.read()
 else:
     # from travis-ci or appveyor
-    TESTINGKEY = os.environ.get('KEEPAKEY')
-    WEAKTESTINGKEY = os.environ.get('WEAKKEEPAKEY')
+    TESTINGKEY = os.environ['KEEPAKEY']
+    WEAKTESTINGKEY = os.environ['WEAKKEEPAKEY']
 
 # harry potter book ISBN
 PRODUCT_ASIN = '0439064872'
 
-# ASINs of a bunch of chairs
+
+# ASINs of a bunch of chairs generated with
 # categories = API.search_for_categories('chairs')
 # asins = []
 # for category in categories:
 #     asins.extend(API.best_sellers_query(category))
 # PRODUCT_ASINS = asins[:40]
+
 
 PRODUCT_ASINS = ['B00IAPNWG6', 'B01CUJMSB2', 'B01CUJMRLI',
                  'B00BMPT7CE', 'B00IAPNWE8', 'B0127O51FK',
@@ -118,6 +121,13 @@ def test_product_finder_query(api):
 #     products = api.query(PRODUCT_ASINS)
 #     assert (time.time() - t_start) > 1
 #     keepa.interface.REQLIM = 2
+
+
+def test_productquery_raw(api):
+    request = api.query(PRODUCT_ASIN, history=False, raw=True)
+    raw = request[0]
+    assert isinstance(raw, requests.Response)
+    assert PRODUCT_ASIN in raw.text
 
 
 def test_productquery_nohistory(api):


### PR DESCRIPTION
This PR adds product keys and resolves #106.  Also resolves #84 by adding an option to return the raw response from the `requests` library.

Finally, resolves #101 by implementing a basic 10 second timeout to for keepa requests.  This will not cause long downloads to timeout, but rather the initial request.  See https://stackoverflow.com/a/21966169/3369879.