### PR TITLE
add brief reference to product-object in keepa.com documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,8 +274,8 @@ Finally, `create a pull request`_ from your fork and I'll be sure to review it.
 Credits
 -------
 This Python module, written by Alex Kaszynski and several contribitors, is
-based on Java code written by Marius Johann, CEO keepa. Java source is can be
-found at `api_backend <https://github.com/keepacom/api_backend/>`_.
+based on Java code written by Marius Johann, CEO Keepa. Java source is can be
+found at `keepacom/api_backend <https://github.com/keepacom/api_backend/>`_.
 
 
 License

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,8 +89,8 @@ html_theme_options = {
     "collapse_navigation": True,
     "use_edit_page_button": True,
     "logo": {
-        "image_light": "_static/keepa-logo.png",
-        "image_dark": "_static/keepa-logo.png",
+        "image_light": "keepa-logo.png",
+        "image_dark": "keepa-logo.png",
     },
 }
 

--- a/keepa/interface.py
+++ b/keepa/interface.py
@@ -614,7 +614,9 @@ class Keepa:
 
         Notes
         -----
-        The following are data fields a product dictionary
+        The following are some of the fields a product dictionary. For a full
+        list and description, please see:
+        `product-object <https://keepa.com/#!discuss/t/product-object/116>`_
 
         AMAZON
             Amazon price history


### PR DESCRIPTION
Resolve #66 by adding in a link to the official documentation.
