### PR TITLE
use named environment

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [unit_testing]
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: deployment
       url: https://pypi.org/p/keepa
     permissions:
       id-token: write  # this permission is mandatory for trusted publishing


### PR DESCRIPTION
This fixes the failed deployment step by using the correct env name.
