### PR TITLE
video param changes for product object query

### DIFF
--- a/src/keepa/interface.py
+++ b/src/keepa/interface.py
@@ -514,6 +514,7 @@ class Keepa:
         days: Optional[int] = None,
         only_live_offers: Optional[bool] = None,
         raw: bool = False,
+        videos: bool = False,
     ) -> List[Dict[str, Any]]:
         """Perform a product query of a list, array, or single ASIN.
 
@@ -631,6 +632,15 @@ class Keepa:
         raw : bool, default; False
             When ``True``, return the raw request response. This is
             only available in the non-async class.
+
+        videos : bool, optional
+            Token Cost: No extra token cost
+
+            Boolean value (0 = false, 1 = true). If specified and set to 1, the
+            videos metadata will be provided when available. Using this
+            parameter does not trigger an update to the videos data; it only
+            gives access to our existing data if available. If you need
+            up-to-date data, you have to use the offers parameter.
 
         Returns
         -------
@@ -889,6 +899,7 @@ class Keepa:
                 days=days,
                 only_live_offers=only_live_offers,
                 raw=raw,
+                videos=videos,
             )
             idx += nrequest
             if raw:
@@ -973,6 +984,7 @@ class Keepa:
         kwargs["history"] = int(kwargs["history"])
         kwargs["rating"] = int(kwargs["rating"])
         kwargs["buybox"] = int(kwargs["buybox"])
+        kwargs["videos"] = int(kwargs["videos"])
 
         if kwargs["update"] is None:
             del kwargs["update"]


### PR DESCRIPTION
This commit adds in the videos parameter to be able to include video data in the product object