### PR TITLE
Add Content Permission for Release Step

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -70,7 +70,8 @@ jobs:
       name: pypi
       url: https://pypi.org/p/keepa
     permissions:
-      id-token: write  # this permission is mandatory for trusted publishing
+      id-token: write  # Required for PyPI publishing
+      contents: write  # Required for creating GitHub releases
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Fix failing release step in https://github.com/akaszynski/keepa/actions/runs/13184254193/job/36802724010 by adding contents permission.
