### PR TITLE
Use returned user status and don't query

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ ci:
   autoupdate_schedule: quarterly
 repos:
 - repo: https://github.com/keewis/blackdoc
-  rev: v0.3.9
+  rev: v0.4.1
   hooks:
   - id: blackdoc
     files: \.py$
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.8
+  rev: v0.12.1
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --exit-non-zero-on-fix]
     exclude: ^(docs/|tests)
   - id: ruff-format
@@ -28,7 +28,7 @@ repos:
     additional_dependencies: [toml]
     exclude: tests/
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.19.1
+  rev: v3.20.0
   hooks:
   - id: pyupgrade
     args: [--py39-plus, --keep-runtime-typing]
@@ -41,7 +41,7 @@ repos:
     args: [--branch, main]
   - id: requirements-txt-fixer
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.14.0
+  rev: v2.15.0
   hooks:
   - id: pretty-format-toml
     args: [--autofix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
   rev: v3.19.1
   hooks:
   - id: pyupgrade
-    args: [--py38-plus, --keep-runtime-typing]
+    args: [--py39-plus, --keep-runtime-typing]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v5.0.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ test = [
   "pandas",
   "pytest-asyncio",
   "pytest-cov",
-  "pytest"
+  "pytest",
+  "pytest-rerunfailures"
 ]
 
 [project.urls]

--- a/src/keepa/data_models.py
+++ b/src/keepa/data_models.py
@@ -1,6 +1,6 @@
 """Contains the data models for keepa requests."""
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -32,7 +32,7 @@ class ProductParams(BaseModel):
 
     """
 
-    author: Optional[Union[List[str], str]] = None
+    author: Optional[Union[list[str], str]] = None
     availabilityAmazon: Optional[int] = None
     avg180_AMAZON_lte: Optional[int] = None
     avg180_AMAZON_gte: Optional[int] = None
@@ -353,19 +353,19 @@ class ProductParams(BaseModel):
     backInStock_USED_NEW_SHIPPING: Optional[bool] = None
     backInStock_USED_VERY_GOOD_SHIPPING: Optional[bool] = None
     backInStock_WAREHOUSE: Optional[bool] = None
-    binding: Optional[Union[List[str], str]] = None
-    brand: Optional[Union[List[str], str]] = None
+    binding: Optional[Union[list[str], str]] = None
+    brand: Optional[Union[list[str], str]] = None
     buyBoxIsAmazon: Optional[bool] = None
     buyBoxIsFBA: Optional[bool] = None
     buyBoxIsUnqualified: Optional[bool] = None
-    buyBoxSellerId: Optional[Union[List[str], str]] = None
+    buyBoxSellerId: Optional[Union[list[str], str]] = None
     buyBoxUsedCondition_lte: Optional[int] = None
     buyBoxUsedCondition_gte: Optional[int] = None
     buyBoxUsedIsFBA: Optional[bool] = None
     buyBoxUsedSellerId: Optional[str] = None
-    categories_include: Optional[Union[List[int], int]] = None
-    categories_exclude: Optional[Union[List[int], int]] = None
-    color: Optional[Union[List[str], str]] = None
+    categories_include: Optional[Union[list[int], int]] = None
+    categories_exclude: Optional[Union[list[int], int]] = None
+    color: Optional[Union[list[str], str]] = None
     couponOneTimeAbsolute_lte: Optional[int] = None
     couponOneTimeAbsolute_gte: Optional[int] = None
     couponOneTimePercent_lte: Optional[int] = None
@@ -952,11 +952,11 @@ class ProductParams(BaseModel):
     deltaPercent90_USED_VERY_GOOD_SHIPPING_gte: Optional[int] = None
     deltaPercent90_WAREHOUSE_lte: Optional[int] = None
     deltaPercent90_WAREHOUSE_gte: Optional[int] = None
-    edition: Optional[Union[List[str], str]] = None
+    edition: Optional[Union[list[str], str]] = None
     fbaFees_lte: Optional[int] = None
     fbaFees_gte: Optional[int] = None
-    format: Optional[Union[List[str], str]] = None
-    genre: Optional[Union[List[str], str]] = None
+    format: Optional[Union[list[str], str]] = None
+    genre: Optional[Union[list[str], str]] = None
     hasParentASIN: Optional[bool] = None
     hasReviews: Optional[bool] = None
     isAdultProduct: Optional[bool] = None
@@ -1005,8 +1005,8 @@ class ProductParams(BaseModel):
     itemWeight_gte: Optional[int] = None
     itemWidth_lte: Optional[int] = None
     itemWidth_gte: Optional[int] = None
-    label: Optional[Union[List[str], str]] = None
-    languages: Optional[Union[List[str], str]] = None
+    label: Optional[Union[list[str], str]] = None
+    languages: Optional[Union[list[str], str]] = None
     lastOffersUpdate_lte: Optional[int] = None
     lastOffersUpdate_gte: Optional[int] = None
     lastPriceChange_lte: Optional[int] = None
@@ -1021,8 +1021,8 @@ class ProductParams(BaseModel):
     lightningStart_gte: Optional[int] = None
     listedSince_lte: Optional[int] = None
     listedSince_gte: Optional[int] = None
-    manufacturer: Optional[Union[List[str], str]] = None
-    model: Optional[Union[List[str], str]] = None
+    manufacturer: Optional[Union[list[str], str]] = None
+    model: Optional[Union[list[str], str]] = None
     newPriceIsMAP: Optional[bool] = None
     nextUpdate_lte: Optional[int] = None
     nextUpdate_gte: Optional[int] = None
@@ -1058,13 +1058,13 @@ class ProductParams(BaseModel):
     packageWeight_gte: Optional[int] = None
     packageWidth_lte: Optional[int] = None
     packageWidth_gte: Optional[int] = None
-    partNumber: Optional[Union[List[str], str]] = None
-    platform: Optional[Union[List[str], str]] = None
-    productGroup: Optional[Union[List[str], str]] = None
+    partNumber: Optional[Union[list[str], str]] = None
+    platform: Optional[Union[list[str], str]] = None
+    productGroup: Optional[Union[list[str], str]] = None
     productType: Optional[int] = None
     publicationDate_lte: Optional[int] = None
     publicationDate_gte: Optional[int] = None
-    publisher: Optional[Union[List[str], str]] = None
+    publisher: Optional[Union[list[str], str]] = None
     releaseDate_lte: Optional[int] = None
     releaseDate_gte: Optional[int] = None
     rootCategory: Optional[int] = None
@@ -1079,11 +1079,11 @@ class ProductParams(BaseModel):
     salesRankReference: Optional[int] = None
     salesRankTopPct_lte: Optional[int] = None
     salesRankTopPct_gte: Optional[int] = None
-    sellerIds: Optional[Union[List[str], str]] = None
-    sellerIdsLowestFBA: Optional[Union[List[str], str]] = None
-    sellerIdsLowestFBM: Optional[Union[List[str], str]] = None
-    size: Optional[Union[List[str], str]] = None
-    studio: Optional[Union[List[str], str]] = None
+    sellerIds: Optional[Union[list[str], str]] = None
+    sellerIdsLowestFBA: Optional[Union[list[str], str]] = None
+    sellerIdsLowestFBM: Optional[Union[list[str], str]] = None
+    size: Optional[Union[list[str], str]] = None
+    studio: Optional[Union[list[str], str]] = None
     title: Optional[str] = None
     title_flag: Optional[str] = None
     totalOfferCount_lte: Optional[int] = None
@@ -1095,7 +1095,7 @@ class ProductParams(BaseModel):
     buyBoxIsPreorder: Optional[bool] = None
     buyBoxIsBackorder: Optional[bool] = None
     buyBoxIsPrimeExclusive: Optional[bool] = None
-    type: Optional[Union[List[str], str]] = None
+    type: Optional[Union[list[str], str]] = None
     warehouseCondition: Optional[int] = None
     singleVariation: Optional[bool] = None
     outOfStockPercentage90_lte: Optional[int] = None

--- a/src/keepa/interface.py
+++ b/src/keepa/interface.py
@@ -5,8 +5,9 @@ import datetime
 import json
 import logging
 import time
+from collections.abc import Sequence
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Union
 
 import aiohttp
 import numpy as np
@@ -53,7 +54,7 @@ DCODES = ["RESERVED", "US", "GB", "DE", "FR", "JP", "CA", "CN", "IT", "ES", "IN"
 # https://github.com/keepacom/api_backend
 # see api_backend/src/main/java/com/keepa/api/backend/structs/Product.java
 # [index in csv, key name, isfloat(is price or rating)]
-csv_indices: List[Tuple[int, str, bool]] = [
+csv_indices: list[tuple[int, str, bool]] = [
     (0, "AMAZON", True),
     (1, "NEW", True),
     (2, "USED", True),
@@ -89,7 +90,7 @@ csv_indices: List[Tuple[int, str, bool]] = [
 ]
 
 
-def _parse_stats(stats: Dict[str, Union[None, int, List[int]]], to_datetime: bool):
+def _parse_stats(stats: dict[str, Union[None, int, list[int]]], to_datetime: bool):
     """Parse numeric stats object.
 
     There is no need to parse strings or list of strings. Keepa stats object
@@ -441,10 +442,10 @@ class Keepa:
         if logging_level not in levels:
             raise TypeError("logging_level must be one of: " + ", ".join(levels))
         log.setLevel(logging_level)
-        # Store user's available tokens
-        log.info("Connecting to keepa using key ending in %s", accesskey[-6:])
-        self.status = self.update_status()
-        log.info("%d tokens remain", self.tokens_left)
+
+        # Don't check available tokens on init
+        log.info("Using key ending in %s", accesskey[-6:])
+        self.status = {"tokensLeft": None, "refillIn": None, "refillRate": None, "timestamp": None}
 
     @property
     def time_to_refill(self) -> float:
@@ -478,7 +479,7 @@ class Keepa:
         # Return value in seconds
         return timetorefil / 1000.0
 
-    def update_status(self) -> Dict[str, Any]:
+    def update_status(self) -> dict[str, Any]:
         """Update available tokens."""
         status = self._request("token", {"key": self.accesskey}, wait=False)
         self.status = status
@@ -516,8 +517,8 @@ class Keepa:
         raw: bool = False,
         videos: bool = False,
         aplus: bool = False,
-        extra_params: Dict[str, Any] = {},
-    ) -> List[Dict[str, Any]]:
+        extra_params: dict[str, Any] = {},
+    ) -> list[dict[str, Any]]:
         """Perform a product query of a list, array, or single ASIN.
 
         Returns a list of product data with one entry for each
@@ -877,18 +878,19 @@ class Keepa:
                 raise ValueError('Parameter "offers" must be between 20 and 100')
 
         # Report time to completion
-        tcomplete = (
-            float(nitems - self.tokens_left) / self.status["refillRate"]
-            - (60000 - self.status["refillIn"]) / 60000.0
-        )
-        if tcomplete < 0.0:
-            tcomplete = 0.5
-        log.debug(
-            "Estimated time to complete %d request(s) is %.2f minutes",
-            nitems,
-            tcomplete,
-        )
-        log.debug("\twith a refill rate of %d token(s) per minute", self.status["refillRate"])
+        if self.status["refillRate"] is not None:
+            tcomplete = (
+                float(nitems - self.tokens_left) / self.status["refillRate"]
+                - (60000 - self.status["refillIn"]) / 60000.0
+            )
+            if tcomplete < 0.0:
+                tcomplete = 0.5
+            log.debug(
+                "Estimated time to complete %d request(s) is %.2f minutes",
+                nitems,
+                tcomplete,
+            )
+            log.debug("\twith a refill rate of %d token(s) per minute", self.status["refillRate"])
 
         # product list
         products = []
@@ -1046,6 +1048,9 @@ class Keepa:
         response = self._request("product", kwargs, wait=wait, raw_response=raw_response)
 
         if kwargs["history"] and not raw_response:
+            if "products" not in response:
+                raise RuntimeError("No products in response. Possibly invalid ASINs")
+
             for product in response["products"]:
                 if product["csv"]:  # if data exists
                     product["data"] = parse_csv(product["csv"], to_datetime, out_of_stock_as_nan)
@@ -1397,11 +1402,11 @@ class Keepa:
 
     def product_finder(
         self,
-        product_parms: Union[Dict[str, Any], ProductParams],
+        product_parms: Union[dict[str, Any], ProductParams],
         domain: Union[str, Domain] = "US",
         wait: bool = True,
         n_products: int = 50,
-    ) -> List[str]:
+    ) -> list[str]:
         """Query the keepa product database to find products matching criteria.
 
         Almost all product fields can be searched for and sorted.
@@ -1622,15 +1627,12 @@ class Keepa:
 
         return self._request("deal", payload, wait=wait)["deals"]
 
-    def _request(self, request_type, payload, wait=True, raw_response=False):
+    def _request(self, request_type, payload, wait: bool = True, raw_response: bool = False):
         """Query keepa api server.
 
         Parses raw response from keepa into a json format. Handles errors and
         waits for available tokens if allowed.
         """
-        if wait:
-            self.wait_for_tokens()
-
         while True:
             raw = requests.get(
                 f"https://api.keepa.com/{request_type}/?",
@@ -1638,33 +1640,36 @@ class Keepa:
                 timeout=self._timeout,
             )
             status_code = str(raw.status_code)
-            if status_code != "200":
-                if status_code in SCODES:
-                    if status_code == "429" and wait:
-                        print("Response from server: %s" % SCODES[status_code])
-                        self.wait_for_tokens()
-                        continue
-                    else:
-                        raise RuntimeError(SCODES[status_code])
-                else:
-                    raise RuntimeError(f"REQUEST_FAILED: {status_code}")
-            break
 
-        response = raw.json()
+            try:
+                response = raw.json()
+            except Exception:
+                raise RuntimeError(f"Invalid JSON from Keepa API (status {status_code})")
 
-        if "tokensConsumed" in response:
-            log.debug("%d tokens consumed", response["tokensConsumed"])
+            # user status is always returned
+            if "tokensLeft" in response:
+                self.tokens_left = response["tokensLeft"]
+                self.status["tokensLeft"] = self.tokens_left
+                log.info("%d tokens remain", self.tokens_left)
+            for key in ["refillIn", "refillRate", "timestamp"]:
+                if key in response:
+                    self.status[key] = response[key]
 
-        if "error" in response:
-            if response["error"]:
-                raise Exception(response["error"]["message"])
+            if status_code == "200":
+                if raw_response:
+                    return raw
+                return response
 
-        # always update tokens
-        self.tokens_left = response["tokensLeft"]
+            if status_code == "429" and wait:
+                tdelay = self.time_to_refill
+                log.warning("Waiting %.0f seconds for additional tokens", tdelay)
+                time.sleep(tdelay)
+                continue
 
-        if raw_response:
-            return raw
-        return response
+            # otherwise, it's an error code
+            if status_code in SCODES:
+                raise RuntimeError(SCODES[status_code])
+            raise RuntimeError(f"REQUEST_FAILED. Status code: {status_code}")
 
 
 class AsyncKeepa:
@@ -1731,14 +1736,11 @@ class AsyncKeepa:
         """Create the async object."""
         self = AsyncKeepa()
         self.accesskey = accesskey
-        self.status = None
         self.tokens_left = 0
         self._timeout = timeout
 
-        # Store user's available tokens
-        log.info("Connecting to keepa using key ending in %s", accesskey[-6:])
-        await self.update_status()
-        log.info("%d tokens remain", self.tokens_left)
+        # don't update the user status on init
+        self.status = {"tokensLeft": None, "refillIn": None, "refillRate": None, "timestamp": None}
         return self
 
     @property
@@ -1797,7 +1799,7 @@ class AsyncKeepa:
         raw: bool = False,
         videos: bool = False,
         aplus: bool = False,
-        extra_params: Dict[str, Any] = {},
+        extra_params: dict[str, Any] = {},
     ):
         """Documented in Keepa.query."""
         if raw:
@@ -1825,18 +1827,19 @@ class AsyncKeepa:
                 raise ValueError('Parameter "offers" must be between 20 and 100')
 
         # Report time to completion
-        tcomplete = (
-            float(nitems - self.tokens_left) / self.status["refillRate"]
-            - (60000 - self.status["refillIn"]) / 60000.0
-        )
-        if tcomplete < 0.0:
-            tcomplete = 0.5
-        log.debug(
-            "Estimated time to complete %d request(s) is %.2f minutes",
-            nitems,
-            tcomplete,
-        )
-        log.debug("\twith a refill rate of %d token(s) per minute", self.status["refillRate"])
+        if self.status["refillRate"] is not None:
+            tcomplete = (
+                float(nitems - self.tokens_left) / self.status["refillRate"]
+                - (60000 - self.status["refillIn"]) / 60000.0
+            )
+            if tcomplete < 0.0:
+                tcomplete = 0.5
+            log.debug(
+                "Estimated time to complete %d request(s) is %.2f minutes",
+                nitems,
+                tcomplete,
+            )
+            log.debug("\twith a refill rate of %d token(s) per minute", self.status["refillRate"])
 
         # product list
         products = []
@@ -1920,7 +1923,7 @@ class AsyncKeepa:
         else:
             kwargs["only-live-offers"] = int(kwargs.pop("only_live_offers"))
             # Keepa's param actually doesn't use snake_case.
-            # I believe using snake case throughout the Keepa interface is better.
+            # Keeping with snake case for consistency
 
         if kwargs["days"] is None:
             del kwargs["days"]
@@ -1940,8 +1943,13 @@ class AsyncKeepa:
         # Query and replace csv with parsed data if history enabled
         wait = kwargs.get("wait")
         kwargs.pop("wait", None)
-        response = await self._request("product", kwargs, wait=wait)
+
+        raw_response = kwargs.pop("raw", False)
+        response = await self._request("product", kwargs, wait=wait, raw_response=raw_response)
         if kwargs["history"]:
+            if "products" not in response:
+                raise RuntimeError("No products in response. Possibly invalid ASINs")
+
             for product in response["products"]:
                 if product["csv"]:  # if data exists
                     product["data"] = parse_csv(product["csv"], to_datetime, out_of_stock_as_nan)
@@ -2044,11 +2052,11 @@ class AsyncKeepa:
     @is_documented_by(Keepa.product_finder)
     async def product_finder(
         self,
-        product_parms: Union[Dict[str, Any], ProductParams],
+        product_parms: Union[dict[str, Any], ProductParams],
         domain: Union[str, Domain] = "US",
         wait: bool = True,
         n_products: int = 50,
-    ) -> List[str]:
+    ) -> list[str]:
         """Documented by Keepa.product_finder."""
         if isinstance(product_parms, dict):
             product_parms_valid = ProductParams(**product_parms)
@@ -2088,7 +2096,7 @@ class AsyncKeepa:
         deals = await self._request("deal", payload, wait=wait)
         return deals["deals"]
 
-    async def _request(self, request_type, payload, wait=True):
+    async def _request(self, request_type, payload, wait: bool = True, raw_response: bool = False):
         """Documented in Keepa._request."""
         while True:
             async with aiohttp.ClientSession() as session:
@@ -2098,26 +2106,36 @@ class AsyncKeepa:
                     timeout=self._timeout,
                 ) as raw:
                     status_code = str(raw.status)
-                    if status_code != "200":
-                        if status_code in SCODES:
-                            if status_code == "429" and wait:
-                                await self.wait_for_tokens()
-                                continue
-                            else:
-                                raise Exception(SCODES[status_code])
-                        else:
-                            raise Exception("REQUEST_FAILED")
 
-                    response = await raw.json()
+                    try:
+                        response = await raw.json()
+                    except Exception:
+                        raise RuntimeError(f"Invalid JSON from Keepa API (status {status_code})")
 
-                    if "error" in response:
-                        if response["error"]:
-                            raise Exception(response["error"]["message"])
+                    # user status is always returned
+                    if "tokensLeft" in response:
+                        self.tokens_left = response["tokensLeft"]
+                        self.status["tokensLeft"] = self.tokens_left
+                        log.info("%d tokens remain", self.tokens_left)
+                    for key in ["refillIn", "refillRate", "timestamp"]:
+                        if key in response:
+                            self.status[key] = response[key]
 
-                    # always update tokens
-                    self.tokens_left = response["tokensLeft"]
-                    return response
-            break
+                    if status_code == "200":
+                        if raw_response:
+                            return raw
+                        return response
+
+                    if status_code == "429" and wait:
+                        tdelay = self.time_to_refill
+                        log.warning("Waiting %.0f seconds for additional tokens", tdelay)
+                        time.sleep(tdelay)
+                        continue
+
+                    # otherwise, it's an error code
+                    if status_code in SCODES:
+                        raise RuntimeError(SCODES[status_code])
+                    raise RuntimeError(f"REQUEST_FAILED. Status code: {status_code}")
 
 
 def convert_offer_history(csv, to_datetime=True):
@@ -2159,7 +2177,7 @@ def _str_to_bool(string: str):
     return False
 
 
-def process_used_buybox(buybox_info: List[str]) -> pd.DataFrame:
+def process_used_buybox(buybox_info: list[str]) -> pd.DataFrame:
     """
     Process used buybox information to create a Pandas DataFrame.
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -90,10 +90,7 @@ PRODUCT_ASINS = [
 # open connection to keepa
 @pytest.fixture(scope="module")
 def api():
-    keepa_api = keepa.Keepa(TESTINGKEY)
-    assert keepa_api.tokens_left
-    assert keepa_api.time_to_refill >= 0
-    return keepa_api
+    return keepa.Keepa(TESTINGKEY)
 
 
 def test_deals(api):
@@ -180,8 +177,8 @@ def test_productquery_nohistory(api):
 
 
 def test_not_an_asin(api):
-    with pytest.raises(Exception):
-        asins = ["0000000000", "000000000x"]
+    with pytest.raises(RuntimeError, match="invalid ASINs"):
+        asins = ["XXXXXXXXXX"]
         api.query(asins)
 
 
@@ -221,7 +218,7 @@ def test_productquery_update(api):
     assert "stats" in product
 
     # no offers requested by default
-    assert product["offers"] is None
+    assert "offers" not in product or product["offers"] is None
 
 
 def test_productquery_offers(api):


### PR DESCRIPTION
Keepa API client has been updated to remove redundant requests to the `/token` endpoint by eliminating the proactive `wait_for_tokens()` check before each API call. Token state is now maintained reactively using data included in all primary API responses, reducing overall request volume and latency.

Tokens also no longer checked on initialization.
